### PR TITLE
Add Codex setup script

### DIFF
--- a/.tools/codex/setup.sh
+++ b/.tools/codex/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Change to repository root if script is run from elsewhere
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Copy example environment files if they don't already exist
+cp -n .env.example .env.local 2>/dev/null || true
+cp -n backend/.env.example backend/.env 2>/dev/null || true
+
+# Install Node.js dependencies
+npm ci
+cd frontend && npm ci && cd ..
+
+# Set up Python virtual environment and install backend dependencies
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r backend/requirements.txt
+deactivate

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ flake8                       # Lint code
 
 ## 🧪 Testing
 
+Run `.tools/codex/setup.sh` before executing tests to ensure all dependencies are installed.
+
 ### Frontend Tests
 - **Unit Tests**: Jest + React Testing Library
 - **E2E Tests**: Playwright


### PR DESCRIPTION
## Summary
- add a setup helper script under `.tools/codex` for Codex
- document running this script before executing tests

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'anthropic')*