### PR TITLE
Add CI workflow and sample tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: ./.tools/codex/setup.sh
+      - name: Run frontend tests
+        run: npm run test:frontend
+      - name: Run backend tests
+        run: npm run test:backend

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Run `.tools/codex/setup.sh` before executing tests to ensure all dependencies ar
 - **Integration Tests**: pytest with test database
 - **API Tests**: pytest + httpx
 
+### Continuous Integration
+Automated GitHub Actions run the full test suite on every pull request.
+
 ## 🚢 Deployment
 
 ### Docker Deployment

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_login_success():
+    payload = {"email": "demo@playbookwiz.com", "password": "demo123"}
+    response = client.post('/api/v1/auth/login', json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data['access_token'] == 'demo-token-123'
+    assert data['token_type'] == 'bearer'
+
+
+def test_login_failure():
+    payload = {"email": "wrong@example.com", "password": "bad"}
+    response = client.post('/api/v1/auth/login', json=payload)
+    assert response.status_code == 401
+

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.json()['status'] == 'healthy'

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customConfig = {
+  testEnvironment: 'jsdom',
+};
+
+module.exports = createJestConfig(customConfig);

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,16 @@
+import { slugify, isValidEmail, formatFileSize } from './utils';
+
+describe('utils', () => {
+  test('slugify converts strings to URL-friendly slugs', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  test('isValidEmail validates email addresses', () => {
+    expect(isValidEmail('test@example.com')).toBe(true);
+    expect(isValidEmail('invalid-email')).toBe(false);
+  });
+
+  test('formatFileSize formats bytes to human readable', () => {
+    expect(formatFileSize(1024)).toBe('1 KB');
+  });
+});


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- include simple backend tests for auth and health endpoints
- include frontend Jest test for utils
- update README with CI info

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: No module named 'fastapi')*