### PR TITLE
Add Jest to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "author": "PlaybookWiz Team",
   "license": "MIT",
   "devDependencies": {
-    "concurrently": "^8.2.2"
+    "concurrently": "^8.2.2",
+    "jest": "^29.0.0"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
## Summary
- include Jest 29 in root package.json devDependencies

## Testing
- `./tools/codex/setup.sh` *(fails: Exit handler never called)*
- `npm test` *(fails: jest: not found)*